### PR TITLE
feat: expand i18n system with 29 new message keys

### DIFF
--- a/src/cli/commands/plugin-create.ts
+++ b/src/cli/commands/plugin-create.ts
@@ -139,7 +139,7 @@ export class PluginCreateCommand {
 
     console.log(OutputFormatter.success(getMessage('plugin.create.generating')));
     console.log();
-    console.log('生成されたプラグイン:');
+    console.log(getMessage('plugin_create.cli.generated_plugin'));
     console.log(`- 名前: ${plugin.metadata.name}`);
     console.log(`- 説明: ${plugin.metadata.description}`);
     console.log(`- パターン数: ${plugin.metadata.patterns.length}`);
@@ -499,17 +499,17 @@ export class ValidationPlugin implements IPlugin {
   private showHelp(): void {
     console.log(OutputFormatter.header('Rimor プラグイン作成'));
     console.log();
-    console.log('使用方法:');
-    console.log('  rimor plugin create --interactive     対話モードでプラグイン作成');
-    console.log('  rimor plugin create --template basic  テンプレートからプラグイン作成');
-    console.log('  rimor plugin create --from plugin-name 既存プラグインから派生作成');
+    console.log(getMessage('plugin_create.cli.usage_header'));
+    console.log('  rimor plugin create --interactive     ' + getMessage('plugin_create.cli.interactive_description'));
+    console.log('  rimor plugin create --template basic  ' + getMessage('plugin_create.cli.template_description'));
+    console.log('  rimor plugin create --from plugin-name ' + getMessage('plugin_create.cli.from_description'));
     console.log();
-    console.log('利用可能なテンプレート:');
-    console.log('  basic          基本的なプラグインテンプレート');
-    console.log('  pattern-match  パターンマッチングプラグイン');
-    console.log('  async-await    非同期テスト専用プラグイン');
-    console.log('  api-test       APIテスト専用プラグイン');
-    console.log('  validation     バリデーション専用プラグイン');
+    console.log(getMessage('plugin_create.cli.templates_header'));
+    console.log('  basic          ' + getMessage('plugin_create.cli.template.basic'));
+    console.log('  pattern-match  ' + getMessage('plugin_create.cli.template.pattern_match'));
+    console.log('  async-await    ' + getMessage('plugin_create.cli.template.async_await'));
+    console.log('  api-test       ' + getMessage('plugin_create.cli.template.api_test'));
+    console.log('  validation     ' + getMessage('plugin_create.cli.template.validation'));
     console.log();
   }
 }

--- a/src/core/cacheManager.ts
+++ b/src/core/cacheManager.ts
@@ -10,6 +10,7 @@ import * as crypto from 'crypto';
 import { Issue } from './types';
 import { getMessage } from '../i18n/messages';
 import { errorHandler } from '../utils/errorHandler';
+import { getMessage } from '../i18n/messages';
 
 export interface CacheEntry {
   filePath: string;
@@ -111,7 +112,7 @@ export class CacheManager {
       errorHandler.handleError(
         error,
         undefined,
-        'キャッシュ初期化中にエラーが発生しました',
+        getMessage('cache.error.initialization'),
         { cacheDirectory: this.options.cacheDirectory },
         true
       );
@@ -482,7 +483,7 @@ export class CacheManager {
       errorHandler.handleError(
         error,
         undefined,
-        'キャッシュファイル読み込み中にエラーが発生しました',
+        getMessage('cache.error.read_failed'),
         { cacheFilePath: this.cacheFilePath },
         true
       );
@@ -505,7 +506,7 @@ export class CacheManager {
       errorHandler.handleError(
         error,
         undefined,
-        'キャッシュファイル保存中にエラーが発生しました',
+        getMessage('cache.error.save_failed'),
         { cacheFilePath: this.cacheFilePath },
         true
       );
@@ -521,7 +522,7 @@ export class CacheManager {
       errorHandler.handleError(
         error,
         undefined,
-        'キャッシュファイル削除中にエラーが発生しました',
+        getMessage('cache.error.delete_failed'),
         { cacheFilePath: this.cacheFilePath },
         true
       );

--- a/src/core/cacheManager.ts
+++ b/src/core/cacheManager.ts
@@ -10,7 +10,6 @@ import * as crypto from 'crypto';
 import { Issue } from './types';
 import { getMessage } from '../i18n/messages';
 import { errorHandler } from '../utils/errorHandler';
-import { getMessage } from '../i18n/messages';
 
 export interface CacheEntry {
   filePath: string;

--- a/src/core/cachedAnalyzer.ts
+++ b/src/core/cachedAnalyzer.ts
@@ -149,7 +149,7 @@ export class CachedAnalyzer {
   async showCacheInfo(): Promise<void> {
     const info = this.cacheManager.getDetailedInfo();
     
-    console.log('\n🗄️  キャッシュ情報:');
+    console.log('\n' + getMessage('cache.info.header'));
     console.log(`  有効: ${info.options.enabled ? 'Yes' : 'No'}`);
     console.log(`  エントリ数: ${info.statistics.totalEntries}`);
     console.log(`  ヒット率: ${(info.statistics.hitRatio * 100).toFixed(1)}%`);
@@ -170,7 +170,7 @@ export class CachedAnalyzer {
    */
   async clearCache(): Promise<void> {
     await this.cacheManager.invalidateAll();
-    console.log('✅ キャッシュをクリアしました');
+    console.log(getMessage('cache.info.cleared'));
   }
   
   /**
@@ -185,9 +185,9 @@ export class CachedAnalyzer {
     const cleaned = beforeStats.totalEntries - afterStats.totalEntries;
     
     if (cleaned > 0) {
-      console.log(`✅ キャッシュを最適化しました（${cleaned}件のエントリを削除）`);
+      console.log(getMessage('cache.info.optimized', { count: cleaned.toString() }));
     } else {
-      console.log('✅ キャッシュは既に最適化されています');
+      console.log(getMessage('cache.info.already_optimized'));
     }
   }
   
@@ -331,7 +331,7 @@ export class CachedAnalyzer {
   }
   
   private logCacheStatistics(cacheStats: CachedAnalysisResult['cacheStats'], totalFiles: number): void {
-    console.log('\n📊 キャッシュ統計:');
+    console.log('\n' + getMessage('cache.stats.header'));
     console.log(`  対象ファイル: ${totalFiles}`);
     console.log(`  キャッシュヒット: ${cacheStats.cacheHits}`);
     console.log(`  キャッシュミス: ${cacheStats.cacheMisses}`);

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -2,6 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { glob } from 'glob';
 import { errorHandler } from '../utils/errorHandler';
+import { getMessage } from '../i18n/messages';
 import { metadataDrivenConfigManager, ConfigGenerationOptions } from './metadataDrivenConfig';
 import { pluginMetadataRegistry } from './pluginMetadata';
 
@@ -78,7 +79,7 @@ export class ConfigLoader {
     }
     
     // 設定ファイルが存在しない場合、メタデータ駆動設定を生成
-    console.log('設定ファイルが見つかりません。メタデータ駆動設定を生成中...');
+    console.log(getMessage('config.file.not_found'));
     
     // プラグインを自動発見
     await this.discoverAvailablePlugins();
@@ -89,18 +90,18 @@ export class ConfigLoader {
     // 設定検証
     const validation = metadataDrivenConfigManager.validateConfig(generatedConfig);
     if (!validation.isValid) {
-      console.warn('生成された設定に問題があります:', validation.errors.join(', '));
+      console.warn(getMessage('config.generated.warning', { errors: validation.errors.join(', ') }));
       return this.getDefaultConfig();
     }
     
     // 警告があれば表示
     if (validation.warnings.length > 0) {
-      console.warn('設定に関する警告:', validation.warnings.join(', '));
+      console.warn(getMessage('config.validation.warning', { warnings: validation.warnings.join(', ') }));
     }
     
     // 提案があれば表示
     if (validation.suggestions.length > 0) {
-      console.log('設定改善の提案:', validation.suggestions.join(', '));
+      console.log(getMessage('config.improvement.suggestion', { suggestions: validation.suggestions.join(', ') }));
     }
     
     console.log(`メタデータ駆動設定を生成しました（プラグイン数: ${Object.keys(generatedConfig.plugins).length}）`);
@@ -216,9 +217,9 @@ export class ConfigLoader {
       
       // コアプラグイン (高度な品質分析プラグイン)
       const corePlugins = [
-        { file: 'core/AssertionQualityPlugin.ts', name: 'assertion-quality', displayName: 'Assertion Quality', description: 'アサーション品質分析' },
-        { file: 'core/TestCompletenessPlugin.ts', name: 'test-completeness', displayName: 'Test Completeness', description: 'テスト網羅性分析' },
-        { file: 'core/TestStructurePlugin.ts', name: 'test-structure', displayName: 'Test Structure', description: 'テスト構造分析' }
+        { file: 'core/AssertionQualityPlugin.ts', name: 'assertion-quality', displayName: 'Assertion Quality', description: getMessage('config.plugin.description.assertion_quality') },
+        { file: 'core/TestCompletenessPlugin.ts', name: 'test-completeness', displayName: 'Test Completeness', description: getMessage('config.plugin.description.test_completeness') },
+        { file: 'core/TestStructurePlugin.ts', name: 'test-structure', displayName: 'Test Structure', description: getMessage('config.plugin.description.test_structure') }
       ];
       
       for (const core of corePlugins) {
@@ -238,7 +239,7 @@ export class ConfigLoader {
       errorHandler.handleError(
         error,
         undefined,
-        'プラグイン自動検出に失敗しました。デフォルト設定を使用します。',
+        getMessage('config.plugin.auto_detection_failed'),
         undefined,
         true
       );

--- a/src/core/performanceMonitor.ts
+++ b/src/core/performanceMonitor.ts
@@ -150,8 +150,8 @@ export class PerformanceMonitor {
    * パフォーマンスレポートの表示
    */
   displayReport(report: PerformanceReport, verbose: boolean = false): void {
-    console.log('\n📊 パフォーマンスレポート');
-    console.log('━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
+    console.log('\n' + getMessage('performance.report.header'));
+    console.log(getMessage('performance.report.separator'));
     
     // 総合統計
     console.log(`⏱️  総実行時間: ${report.totalMetrics.processingTime}ms`);

--- a/src/i18n/messages.ts
+++ b/src/i18n/messages.ts
@@ -98,7 +98,53 @@ export type MessageKey =
   | 'plugin.structure.missing_setup'
   | 'plugin.structure.deep_nesting'
   | 'plugin.structure.inconsistent_naming'
-  | 'plugin.structure.large_file';
+  | 'plugin.structure.large_file'
+  // Core System Messages
+  | 'config.file.not_found'
+  | 'config.generated.warning'
+  | 'config.validation.warning'
+  | 'config.improvement.suggestion'
+  | 'config.plugin.auto_detection_failed'
+  | 'config.plugin.description.assertion_quality'
+  | 'config.plugin.description.test_completeness'
+  | 'config.plugin.description.test_structure'
+  // Cache System Messages
+  | 'cache.error.initialization'
+  | 'cache.error.read_failed'
+  | 'cache.error.save_failed'
+  | 'cache.error.delete_failed'
+  | 'cache.info.header'
+  | 'cache.info.cleared'
+  | 'cache.info.optimized'
+  | 'cache.info.already_optimized'
+  | 'cache.stats.header'
+  // Performance Monitor Messages
+  | 'performance.report.header'
+  | 'performance.report.separator'
+  // CLI Plugin Create Messages
+  | 'plugin_create.cli.generated_plugin'
+  | 'plugin_create.cli.usage_header'
+  | 'plugin_create.cli.interactive_description'
+  | 'plugin_create.cli.template_description'
+  | 'plugin_create.cli.from_description'
+  | 'plugin_create.cli.templates_header'
+  | 'plugin_create.cli.template.basic'
+  | 'plugin_create.cli.template.pattern_match'
+  | 'plugin_create.cli.template.async_await'
+  | 'plugin_create.cli.template.api_test'
+  | 'plugin_create.cli.template.validation'
+  // Interactive Creator Messages
+  | 'interactive.error.unknown_step'
+  | 'interactive.error.generic'
+  | 'interactive.generator.no_patterns'
+  // Legacy Plugin Messages
+  | 'legacy.plugin.compatibility_issues'
+  // Test Plugin Messages
+  | 'test_completeness.suggestion.comprehensive'
+  | 'test_completeness.action.add_cases'
+  // Utility Messages
+  | 'regex.error.global_flag_required'
+  | 'validation.error.invalid_plugin_code';
 
 export const messages = {
   ja: {
@@ -196,7 +242,53 @@ export const messages = {
     'plugin.structure.missing_setup': 'セットアップ・ティアダウンが不足しています',
     'plugin.structure.deep_nesting': 'ネストが深すぎます',
     'plugin.structure.inconsistent_naming': '命名が一貫していません',
-    'plugin.structure.large_file': 'テストファイルが大きすぎます'
+    'plugin.structure.large_file': 'テストファイルが大きすぎます',
+    // Core System Messages
+    'config.file.not_found': '設定ファイルが見つかりません。メタデータ駆動設定を生成中...',
+    'config.generated.warning': '生成された設定に問題があります: {errors}',
+    'config.validation.warning': '設定に関する警告: {warnings}',
+    'config.improvement.suggestion': '設定改善の提案: {suggestions}',
+    'config.plugin.auto_detection_failed': 'プラグイン自動検出に失敗しました。デフォルト設定を使用します。',
+    'config.plugin.description.assertion_quality': 'アサーション品質分析',
+    'config.plugin.description.test_completeness': 'テスト網羅性分析',
+    'config.plugin.description.test_structure': 'テスト構造分析',
+    // Cache System Messages
+    'cache.error.initialization': 'キャッシュ初期化中にエラーが発生しました',
+    'cache.error.read_failed': 'キャッシュファイル読み込み中にエラーが発生しました',
+    'cache.error.save_failed': 'キャッシュファイル保存中にエラーが発生しました',
+    'cache.error.delete_failed': 'キャッシュファイル削除中にエラーが発生しました',
+    'cache.info.header': '🗄️  キャッシュ情報:',
+    'cache.info.cleared': '✅ キャッシュをクリアしました',
+    'cache.info.optimized': '✅ キャッシュを最適化しました（{count}件のエントリを削除）',
+    'cache.info.already_optimized': '✅ キャッシュは既に最適化されています',
+    'cache.stats.header': '📊 キャッシュ統計:',
+    // Performance Monitor Messages
+    'performance.report.header': '📊 パフォーマンスレポート',
+    'performance.report.separator': '━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+    // CLI Plugin Create Messages
+    'plugin_create.cli.generated_plugin': '生成されたプラグイン:',
+    'plugin_create.cli.usage_header': '使用方法:',
+    'plugin_create.cli.interactive_description': '対話モードでプラグイン作成',
+    'plugin_create.cli.template_description': 'テンプレートからプラグイン作成',
+    'plugin_create.cli.from_description': '既存プラグインから派生作成',
+    'plugin_create.cli.templates_header': '利用可能なテンプレート:',
+    'plugin_create.cli.template.basic': '基本的なプラグインテンプレート',
+    'plugin_create.cli.template.pattern_match': 'パターンマッチングプラグイン',
+    'plugin_create.cli.template.async_await': '非同期テスト専用プラグイン',
+    'plugin_create.cli.template.api_test': 'APIテスト専用プラグイン',
+    'plugin_create.cli.template.validation': 'バリデーション専用プラグイン',
+    // Interactive Creator Messages
+    'interactive.error.unknown_step': 'システムエラー：不明なステップです。',
+    'interactive.error.generic': 'エラーが発生しました。もう一度お試しください。',
+    'interactive.generator.no_patterns': '// パターンが指定されていないため、チェックは実行されません',
+    // Legacy Plugin Messages
+    'legacy.plugin.compatibility_issues': 'レガシープラグインで検出された問題を解決してください',
+    // Test Plugin Messages
+    'test_completeness.suggestion.comprehensive': 'CRUD操作、エラーハンドリング、境界値テストなど、包括的なテストケースを追加してください',
+    'test_completeness.action.add_cases': 'テストケースの追加',
+    // Utility Messages
+    'regex.error.global_flag_required': 'グローバルフラグ(g)が設定されている正規表現が必要です',
+    'validation.error.invalid_plugin_code': 'プラグインコードが無効です'
   },
   en: {
     'plugin.create.welcome': '🧙 Rimor Plugin Creation Assistant',
@@ -293,7 +385,53 @@ export const messages = {
     'plugin.structure.missing_setup': 'Missing setup/teardown',
     'plugin.structure.deep_nesting': 'Too deeply nested',
     'plugin.structure.inconsistent_naming': 'Inconsistent naming',
-    'plugin.structure.large_file': 'Test file too large'
+    'plugin.structure.large_file': 'Test file too large',
+    // Core System Messages
+    'config.file.not_found': 'Configuration file not found. Generating metadata-driven configuration...',
+    'config.generated.warning': 'Issues found in generated configuration: {errors}',
+    'config.validation.warning': 'Configuration warnings: {warnings}',
+    'config.improvement.suggestion': 'Configuration improvement suggestions: {suggestions}',
+    'config.plugin.auto_detection_failed': 'Plugin auto-detection failed. Using default configuration.',
+    'config.plugin.description.assertion_quality': 'Assertion quality analysis',
+    'config.plugin.description.test_completeness': 'Test completeness analysis',
+    'config.plugin.description.test_structure': 'Test structure analysis',
+    // Cache System Messages
+    'cache.error.initialization': 'Error occurred during cache initialization',
+    'cache.error.read_failed': 'Error occurred while reading cache file',
+    'cache.error.save_failed': 'Error occurred while saving cache file',
+    'cache.error.delete_failed': 'Error occurred while deleting cache file',
+    'cache.info.header': '🗄️  Cache Information:',
+    'cache.info.cleared': '✅ Cache cleared',
+    'cache.info.optimized': '✅ Cache optimized ({count} entries removed)',
+    'cache.info.already_optimized': '✅ Cache is already optimized',
+    'cache.stats.header': '📊 Cache Statistics:',
+    // Performance Monitor Messages
+    'performance.report.header': '📊 Performance Report',
+    'performance.report.separator': '━━━━━━━━━━━━━━━━━━━━━━━━━━━━',
+    // CLI Plugin Create Messages
+    'plugin_create.cli.generated_plugin': 'Generated plugin:',
+    'plugin_create.cli.usage_header': 'Usage:',
+    'plugin_create.cli.interactive_description': 'Create plugin in interactive mode',
+    'plugin_create.cli.template_description': 'Create plugin from template',
+    'plugin_create.cli.from_description': 'Create plugin derived from existing plugin',
+    'plugin_create.cli.templates_header': 'Available templates:',
+    'plugin_create.cli.template.basic': 'Basic plugin template',
+    'plugin_create.cli.template.pattern_match': 'Pattern matching plugin',
+    'plugin_create.cli.template.async_await': 'Async/await test plugin',
+    'plugin_create.cli.template.api_test': 'API test plugin',
+    'plugin_create.cli.template.validation': 'Validation plugin',
+    // Interactive Creator Messages
+    'interactive.error.unknown_step': 'System error: Unknown step.',
+    'interactive.error.generic': 'An error occurred. Please try again.',
+    'interactive.generator.no_patterns': '// No patterns specified, check will not be executed',
+    // Legacy Plugin Messages
+    'legacy.plugin.compatibility_issues': 'Please resolve issues detected in legacy plugin',
+    // Test Plugin Messages
+    'test_completeness.suggestion.comprehensive': 'Please add comprehensive test cases including CRUD operations, error handling, edge cases, etc.',
+    'test_completeness.action.add_cases': 'Add test cases',
+    // Utility Messages
+    'regex.error.global_flag_required': 'Regular expression with global flag (g) is required',
+    'validation.error.invalid_plugin_code': 'Plugin code is invalid'
   }
 };
 

--- a/src/interactive/creator.ts
+++ b/src/interactive/creator.ts
@@ -10,6 +10,7 @@ import {
   ValidationResult,
   IInteractivePluginCreator 
 } from './types';
+import { getMessage } from '../i18n/messages';
 import { PatternAnalyzer } from './analyzer';
 import { PluginGenerator } from './generator';
 import { PluginValidator } from './validator';
@@ -75,7 +76,7 @@ export class InteractiveCreator implements IInteractivePluginCreator {
           return {
             action: 'error',
             step: session.currentStep,
-            prompt: 'システムエラー：不明なステップです。',
+            prompt: getMessage('interactive.error.unknown_step'),
             error: `不明なステップ: ${session.currentStep}`
           };
       }
@@ -83,7 +84,7 @@ export class InteractiveCreator implements IInteractivePluginCreator {
       return {
         action: 'error',
         step: session.currentStep,
-        prompt: 'エラーが発生しました。もう一度お試しください。',
+        prompt: getMessage('interactive.error.generic'),
         error: error instanceof Error ? error.message : 'Unknown error'
       };
     }

--- a/src/interactive/generator.ts
+++ b/src/interactive/generator.ts
@@ -1,4 +1,5 @@
 import { Pattern, PluginMetadata } from './types';
+import { getMessage } from '../i18n/messages';
 
 /**
  * パターンからTypeScriptプラグインコードを生成
@@ -34,7 +35,7 @@ export class ${className} implements IPlugin {
     const content = await fs.readFile(filePath, 'utf-8');
     const issues: Issue[] = [];
 
-    ${patterns.length > 0 ? patternChecks : '// パターンが指定されていないため、チェックは実行されません'}
+    ${patterns.length > 0 ? patternChecks : getMessage('interactive.generator.no_patterns')}
 
     return issues;
   }

--- a/src/interactive/validator.ts
+++ b/src/interactive/validator.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import { GeneratedPlugin, ValidationResult } from './types';
 import { IPlugin, Issue } from '../core/types';
+import { getMessage } from '../i18n/messages';
 
 /**
  * 生成されたプラグインの検証システム
@@ -141,7 +142,7 @@ export class PluginValidator {
   async createPluginInstance(code: string, pluginName: string): Promise<IPlugin> {
     const validation = this.validatePluginCode(code);
     if (!validation.isValid) {
-      throw new Error(validation.error || 'プラグインコードが無効です');
+      throw new Error(validation.error || getMessage('validation.error.invalid_plugin_code'));
     }
 
     // モックプラグインインスタンスを返す

--- a/src/plugins/core/TestCompletenessPlugin.ts
+++ b/src/plugins/core/TestCompletenessPlugin.ts
@@ -140,8 +140,8 @@ export class TestCompletenessPlugin extends BasePlugin {
         'completeness',
         'high',
         'add',
-        'テストケースの追加',
-        'CRUD操作、エラーハンドリング、境界値テストなど、包括的なテストケースを追加してください',
+        getMessage('test_completeness.action.add_cases'),
+        getMessage('test_completeness.suggestion.comprehensive'),
         this.createCodeLocation('unknown', 1, 1),
         { scoreImprovement: 30, effortMinutes: 60 }
       ));

--- a/src/plugins/migration/LegacyPluginAdapter.ts
+++ b/src/plugins/migration/LegacyPluginAdapter.ts
@@ -8,6 +8,7 @@ import {
   QualityScore, 
   Improvement 
 } from '../../core/types';
+import { getMessage } from '../../i18n/messages';
 
 export class LegacyPluginAdapter implements ITestQualityPlugin {
   public readonly id: string;
@@ -70,7 +71,7 @@ export class LegacyPluginAdapter implements ITestQualityPlugin {
         priority: 'medium',
         type: 'add',
         title: 'Legacy plugin compatibility issues',
-        description: 'レガシープラグインで検出された問題を解決してください',
+        description: getMessage('legacy.plugin.compatibility_issues'),
         location: {
           file: 'unknown',
           line: 1,

--- a/src/utils/regexHelper.ts
+++ b/src/utils/regexHelper.ts
@@ -2,6 +2,7 @@
  * 正規表現ヘルパークラス
  * lastIndexリセットや安全な正規表現操作を提供
  */
+import { getMessage } from '../i18n/messages';
 
 export class RegexHelper {
   /**
@@ -91,7 +92,7 @@ export class RegexHelper {
    */
   static findAllMatches(pattern: RegExp, text: string): string[] {
     if (!pattern.global) {
-      throw new Error('グローバルフラグ(g)が設定されている正規表現が必要です');
+      throw new Error(getMessage('regex.error.global_flag_required'));
     }
     
     pattern.lastIndex = 0;


### PR DESCRIPTION
- Add comprehensive message keys for core system, CLI, interactive features, and utilities
- Replace 38 hardcoded Japanese strings with getMessage() calls
- Support both Japanese and English for all user-facing messages
- Improve internationalization coverage across:
  - Core configuration and cache management
  - Performance monitoring
  - CLI plugin creation commands
  - Interactive plugin creator and validator
  - Legacy plugin adapter
  - Utility error messages