### PR TITLE
feat: CI工程にNode.js 22.xを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## 概要
v0.8.0で削除されたNode.js 22.xのサポートをCIワークフローに復活させます。

## 背景
- v0.8.0のリファクタリング時にNode.js 22.xがCIから削除されました
- Node.js 22はLTS版として広く使用されているため、サポートの継続が重要です

## 変更内容
`.github/workflows/ci.yml`の以下のジョブにNode.js 22.xを追加：

### 1. build-and-verifyジョブ
```diff
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
```

### 2. testジョブ
```diff
-        node-version: [18.x, 20.x]
+        node-version: [18.x, 20.x, 22.x]
```

## 影響
- CIの実行時間が若干増加（Node.js 22.xでのテスト実行分）
- より幅広いNode.jsバージョンでの互換性を保証

## テスト
このPRのCIでNode.js 22.xでのテストが正常に実行されることを確認してください。

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * CIテストの対象Node.jsバージョンに22.xを追加し、より広範なバージョンでの動作確認を実施するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->