### PR TITLE
fix: CI環境でCodeAnnotatorテストの意図的なエラーログを抑制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the Rimor project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2025-08-02
+
+### Fixed
+
+- **CI環境のログクリーン化**: CodeAnnotatorテストの意図的なエラーログを抑制
+  - jest.setup.jsにエラー抑制パターンを追加
+  - CI/CDパイプラインでのログ視認性を改善
+  - プロダクションコードには影響なし (#47)
+
 ## [0.8.0] - 2025-08-02
 
 ### 🏗️ メジャーリファクタリング - コア価値への回帰

--- a/jest.setup.js
+++ b/jest.setup.js
@@ -24,7 +24,9 @@ console.error = (...args) => {
     'UNKNOWN: セキュリティ警告',
     'Context:',
     'セキュリティ警告:',
-    '危険なプロパティ名を検出'
+    '危険なプロパティ名を検出',
+    'Error reading file',
+    'Error cleaning up annotations'
   ];
   
   if (suppressPatterns.some(pattern => message.includes(pattern)) ||


### PR DESCRIPTION
## 概要
CI環境でCodeAnnotatorのテストを実行した際に表示される意図的なエラーログを抑制します。

## 問題
- テストで意図的に発生させているエラーログがCIコンソールに表示されていた
- 実際のエラーと区別しづらく、CIログが汚染されていた

## 修正内容
jest.setup.jsのエラー抑制パターンに以下を追加：
- `'Error reading file'`
- `'Error cleaning up annotations'`

## 影響範囲
- テスト実行時のみエラーログが抑制される
- プロダクションコードには影響なし

## テスト
ローカルでテストを実行し、エラーログが抑制されることを確認済み：
```bash
npm test -- --no-coverage --testPathPattern=CodeAnnotator.test.ts
```

Fixes #47

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * テスト実行時に特定の既知エラーメッセージが表示されないよう、エラーメッセージの抑制パターンを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->